### PR TITLE
fix: nautilus and copper golem equipment desync

### DIFF
--- a/cheetah-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/cheetah-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -85,3 +85,13 @@
      }
  
      private void tryHandleChat(String message, boolean bypassHiddenChat, Runnable handler, boolean sync) { // CraftBukkit
+@@ -2858,7 +_,8 @@
+                                         // Refresh the current entity metadata
+                                         target.refreshEntityData(ServerGamePacketListenerImpl.this.player);
+                                         // SPIGOT-7136 - Allays
+-                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse) { // Paper - Fix horse armor desync
++                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse
++                                            || target instanceof net.minecraft.world.entity.animal.nautilus.AbstractNautilus || target instanceof net.minecraft.world.entity.animal.golem.CopperGolem) { // Paper - Fix horse armor desync // Cheetah - Fix nautilus/copper golem desyncs
+                                             ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(
+                                                 target.getId(), java.util.Arrays.stream(net.minecraft.world.entity.EquipmentSlot.values())
+                                                 .map((slot) -> com.mojang.datafixers.util.Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))

--- a/cheetah-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/cheetah-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -85,13 +85,12 @@
      }
  
      private void tryHandleChat(String message, boolean bypassHiddenChat, Runnable handler, boolean sync) { // CraftBukkit
-@@ -2858,7 +_,8 @@
+@@ -2858,7 +_,7 @@
                                          // Refresh the current entity metadata
                                          target.refreshEntityData(ServerGamePacketListenerImpl.this.player);
                                          // SPIGOT-7136 - Allays
 -                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse) { // Paper - Fix horse armor desync
-+                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse
-+                                            || target instanceof net.minecraft.world.entity.animal.nautilus.AbstractNautilus || target instanceof net.minecraft.world.entity.animal.golem.CopperGolem) { // Paper - Fix horse armor desync // Cheetah - Fix nautilus/copper golem desyncs
++                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse || target instanceof net.minecraft.world.entity.animal.nautilus.AbstractNautilus || target instanceof net.minecraft.world.entity.animal.golem.CopperGolem) { // Paper - Fix horse armor desync // Cheetah - Fix nautilus/copper golem desync
                                              ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(
                                                  target.getId(), java.util.Arrays.stream(net.minecraft.world.entity.EquipmentSlot.values())
                                                  .map((slot) -> com.mojang.datafixers.util.Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))


### PR DESCRIPTION
This pull request resolves a desync issue that occurs when canceling the PlayerInteractEntityEvent and a player attempts to retrieve items from a Nautilus or Copper Golem.

See https://github.com/PaperMC/Paper/pull/13476 and https://github.com/PaperMC/Paper/pull/13013